### PR TITLE
Updated module path

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/looker-open-source/sdk-codegen/go
+module github.com/mkaiser323/sdk-codegen/go
 
 go 1.14
 


### PR DESCRIPTION
The current setup does not work with go modules due to the fact that the go code is in a subfolder. When trying to build, for instance, the following error is returned:

```
go: errors parsing go.mod:
...
require github.com/looker-open-source/sdk-codegen/go: version "v21.0.7" invalid: unknown revision go/v21.0.7
```

According to this thread: https://github.com/golang/go/issues/38592 and this wiki: https://github.com/golang/go/wiki/Modules#publishing-a-release the name of the subfolder must be included in the version tag. 
